### PR TITLE
Leverage built-in `.random` method

### DIFF
--- a/src/battle.js
+++ b/src/battle.js
@@ -5,17 +5,13 @@
 // Author: stahnma
 // Configuration: none
 
-function randomKnow() {
-  var knowing = new Array();
-  knowing[0] = "https://i.imgur.com/yZqAF7e.gif"
-  knowing[1] = "https://i.imgur.com/1jcvTBp.jpg"
-  knowing[2] = "https://i.imgur.com/s88AWgH.png"
-  index = Math.floor(Math.random() * knowing.length);
-  return knowing[index];
-}
-
-module.exports = function(robot) {
-  robot.hear(/knowing is half the battle/i, function(msg) {
-    msg.send(randomKnow());
+module.exports = (robot) => {
+  robot.hear(/knowing is half the battle/i, (msg) => {
+    const knowing = [
+      'https://i.imgur.com/yZqAF7e.gif',
+      'https://i.imgur.com/1jcvTBp.jpg',
+      'https://i.imgur.com/s88AWgH.png',
+    ];
+    msg.send(msg.random(knowing));
   });
-}
+};


### PR DESCRIPTION
**Reference:** https://hubot.github.com/docs/scripting/#random

Prior to this PR, the script called the `randomKnow()` method to pull one of the images in the array off at random before sending it to the user. This PR retains the same end result, but refactors the code to leverage Hubot's built-in `<Response>.random()` method. This cuts down on total lines, while making it a bit easier to maintain should more images be added to the stack in the future.